### PR TITLE
Add flood (1.0-rc1) formula

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -9,3 +9,4 @@
 | rename      | none                         |
 | sc-im       | ncurses >= 6.0               |
 | trickle     | none                         |
+| flood       | none                         |

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ brew install <package>
 + [keuka](https://github.com/nickolasburr/keuka) - SSL/TLS handshake analysis utility.
 + [sc-im](https://github.com/andmarti1424/sc-im) - An ncurses spreadsheet program for terminal.
 + [trickle](https://github.com/sjmulder/trickle) - Slow pipe and terminal.
++ [flood](https://github.com/sjmulder/flood) - Rapidly repeat a command.

--- a/flood.rb
+++ b/flood.rb
@@ -1,0 +1,14 @@
+class Flood < Formula
+  desc     "Rapidly repeat a command"
+  homepage "https://github.com/sjmulder/flood"
+  url      "https://github.com/sjmulder/flood/archive/1.0-rc1.tar.gz"
+  sha256   "dfc79d3595db8f566ca58821d324e0f77fe0b36ff3768b2f709c29cf208cede2"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "${bin}/flood", "-n1", "ls"
+  end
+end


### PR DESCRIPTION
Here’s a formula for a new small tool. Add it if you like it, otherwise no harm done.

Project: https://github.com/sjmulder/flood

Notes:

* I’ve tagged a rc1 version just in case something comes up.
* Not sure if having prebuilt binaries is worth it. It takes only an instant to build.
* The Makefile’s install target seems to work well, given the right prefix.
