### PR TITLE
Remove sc-im ncurses dependency

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,5 +7,5 @@
 | keuka       | openssl >=1.0.2              |
 | mountpoint  | none                         |
 | rename      | none                         |
-| sc-im       | ncurses >= 6.0               |
+| sc-im       | none                         |
 | trickle     | none                         |

--- a/sc-im.rb
+++ b/sc-im.rb
@@ -4,6 +4,7 @@ class ScIm < Formula
   url "https://github.com/andmarti1424/sc-im/archive/v0.6.0.tar.gz"
   sha256 "5da644d380ab3752de283b83cce18c3ba12b068d0762c44193c34367a0dcbc38"
   version "0.6.0"
+  revision 2
 
   bottle do
     root_url "https://dl.bintray.com/nickolasburr/homebrew-bottles"
@@ -13,7 +14,7 @@ class ScIm < Formula
     sha256 "44648a2715d0a3709c66d2c2f520c9077f410fe33ccf89f66ae10503ae7ebe14" => :yosemite
   end
 
-  depends_on "ncurses"
+  patch :DATA
 
   def install
     system "mkdir bin"
@@ -30,3 +31,30 @@ class ScIm < Formula
     system "scim", "--help"
   end
 end
+__END__
+diff --git a/src/Makefile b/src/Makefile
+index 779f8bb..3443037 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -18,7 +18,7 @@ MANDIR  = $(prefix)/man/man1
+ 
+ ifeq ($(shell uname -s),Darwin)
+   NCURSES_CFLAGS ?=
+-  NCURSES_LIBS   ?= -lncursesw
++  NCURSES_LIBS   ?= -lncurses
+ else ifeq ($(shell pkg-config --exists ncursesw || echo 'no'),no)
+   NCURSES_CFLAGS ?=
+   NCURSES_LIBS   ?= -lncursesw
+diff --git a/src/tui.c b/src/tui.c
+index 21f809b..121f65a 100644
+--- a/src/tui.c
++++ b/src/tui.c
+@@ -78,7 +78,7 @@ SCREEN * sstdout;
+ srange * ranges;
+ 
+ void ui_start_screen() {
+-    sstderr = newterm(NULL, stderr, NULL);
++    sstderr = newterm(NULL, stderr, stdin);
+     noecho();
+     sstdout = newterm(NULL, stdout, stdin);
+     set_term(sstdout);


### PR DESCRIPTION
macOS' system ncurses works after applying a small patch, already merged upstream: https://github.com/andmarti1424/sc-im/pull/183

The Makefile tweak for Homebrew builds is pending upstream merge: https://github.com/andmarti1424/sc-im/pull/211

This PR depends on https://github.com/nickolasburr/homebrew-pfa/pull/2

New binaries would have to be built, if that’s desired. The old references are commented out for now.